### PR TITLE
feat!: turn `SetStateWithAnimationExtension` into  `AnimatingStateMixin` for proper ordering of state changes

### DIFF
--- a/packages/fleet/README.md
+++ b/packages/fleet/README.md
@@ -97,7 +97,8 @@ class _MyWidgetState extends State<MyWidget> {
 Now lets animate the state change of `_active`:
 
 ```diff
- class _MyWidgetState extends State<MyWidget> {
+-class _MyWidgetState extends State<MyWidget> {
++class _MyWidgetState extends State<MyWidget> with AnimatingStateMixin {
    var _active = false;
 
    @override
@@ -105,7 +106,7 @@ Now lets animate the state change of `_active`:
      return GestureDetector(
        onTap: () {
 -        setState(() {
-+        setStateWithAnimationAsync(Curves.ease.animation(250.ms), () {
++        setStateAsync(animation: Curves.ease.animation(250.ms), () {
            _active = !_active;
          });
        },
@@ -118,9 +119,13 @@ Now lets animate the state change of `_active`:
  }
 ```
 
-All we did was replace `ColoredBox` with [`AColoredBox`][acoloredbox] and use
-[`setStateWithAnimationAsync`][setstatewithanimationasync] instead of
-`setState`.
+We made the following changes:
+
+1. Mixin `AnimatingStateMixin` to `_MyWidgetState`, so we can use
+   `setStateAsync`.
+2. Use `setStateAsync` to specify the animation that we want to apply to the
+   state change.
+3. Use `AColoredBox` instead of `ColoredBox`.
 
 The `AColoredBox` widget is a drop-in replacement for `ColoredBox` that supports
 animating with Fleet. Widgets that support animating with Fleet don't have any
@@ -133,22 +138,20 @@ state-based animation through components provided by Fleet (see
 [`AnimatableStateMixin`][animatablestatemixin]). Issues or PRs for adding
 support for more widgets are welcome!
 
-Note that we did not explicitly tell `setStateWithAnimationAsync` what to
-animate. This is because Fleet uses a **state-based** approach. All state
-changes caused by executing the provided callback will be animated. Even the
-state changes which are indirect, like the `color` parameter of `AColoredBox`
-going from `Colors.grey` to `Colors.blue`. Fleet does this by tracking the state
-of animatable parameters of animatable widgets from one build to the next.
+Note that we did not explicitly tell `setStateAsync` what to animate. This is
+because Fleet uses a **state-based** approach. All state changes caused by
+executing the provided callback will be animated. Even the state changes which
+are indirect, like the `color` parameter of `AColoredBox` going from
+`Colors.grey` to `Colors.blue`. Fleet does this by tracking the state of
+animatable parameters of animatable widgets from one build to the next.
 
-`setStateWithAnimationAsync` is a little bit special in that it does not
-immediately execute the callback, like it is the case for `setState`. Instead,
-`setStateWithAnimationAsync` executes the callback as part of building the next
-frame. In practice this seldomly makes a difference.
-`setStateWithAnimationAsync` is a method from an extension on `State`.
+`setStateAsync` is a little bit special in that it does not immediately execute
+the callback, like it is the case for `setState`. Instead, `setStateAsync`
+executes the callback as part of building the next frame.
 
 `Curves.ease.animation(250.ms)` creates an [`AnimationSpec`][animationspec] that
-we pass to `setStateWithAnimationAsync` to specify how to animate from the old
-to the new state.
+we pass to `setStateAsync` to specify how to animate from the old to the new
+state.
 
 `.animate` is an extension method on `Curve` that creates an
 [`AnimationSpec`][animationspec] form the curve. It optionally takes a
@@ -187,8 +190,8 @@ for animating with Fleet:
   https://github.com/blaugold/fleet/tree/main/packages/fleet/example
 [withanimationasync]:
   https://pub.dev/documentation/fleet/latest/fleet/withAnimationAsync.html
-[setstatewithanimationasync]:
-  https://pub.dev/documentation/fleet/latest/fleet/SetStateWithAnimationExtension/setStateWithAnimationAsync.html
+[setstateasync]:
+  https://pub.dev/documentation/fleet/latest/fleet/AnimatingStateMixin/setStateAsync.html
 [animatablestatemixin]:
   https://pub.dev/documentation/fleet/latest/fleet/AnimatableStateMixin-mixin.html
 [animationspec]:

--- a/packages/fleet/example/README.md
+++ b/packages/fleet/example/README.md
@@ -7,7 +7,7 @@ demonstrate the Fleet framework:
 - [simple_declarative_animation.dart] shows how to animate in a declarative
   style with `Animated`.
 - [simple_imperative_animation.dart] shows how to animate in an imperative style
-  with `setStateWithAnimationAsync`.
+  with `AnimatingStateMixin.setStateAsync`.
 - [stack.dart] shows how to stagger animations through `AnimatedSpec.delay`.
 
 [interactive_box_fleet.dart]:

--- a/packages/fleet/example/lib/interactive_box_fleet.dart
+++ b/packages/fleet/example/lib/interactive_box_fleet.dart
@@ -25,7 +25,7 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class _MyHomePageState extends State<MyHomePage> with AnimatingStateMixin {
   static final _distanceColorTween =
       ColorTween(begin: Colors.blue, end: Colors.green);
 
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       body: GestureDetector(
         onPanUpdate: (details) {
-          setState(() {
+          setStateAsync(() {
             _alignment += Alignment(
               details.delta.dx / size.width,
               details.delta.dy / size.height,
@@ -48,7 +48,7 @@ class _MyHomePageState extends State<MyHomePage> {
           });
         },
         onPanEnd: (_) {
-          setStateWithAnimationAsync(Curves.ease.animation(300.ms), () {
+          setStateAsync(animation: Curves.ease.animation(300.ms), () {
             _alignment = Alignment.center;
             _color = _distanceColorTween.begin!;
           });

--- a/packages/fleet/example/lib/simple_imperative_animation.dart
+++ b/packages/fleet/example/lib/simple_imperative_animation.dart
@@ -25,7 +25,7 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class _MyHomePageState extends State<MyHomePage> with AnimatingStateMixin {
   static const _collapsedColor = Colors.blue;
   static const _expandedColor = Colors.green;
   static const _collapsedSize = Size.square(300);
@@ -34,14 +34,14 @@ class _MyHomePageState extends State<MyHomePage> {
   var _size = _collapsedSize;
 
   void _collapse() {
-    setStateWithAnimationAsync(Curves.easeInOut.animation(), () {
+    setStateAsync(animation: Curves.easeInOut.animation(), () {
       _color = _collapsedColor;
       _size = _collapsedSize;
     });
   }
 
   void _expand() {
-    setStateWithAnimationAsync(Curves.easeInOutExpo.animation(1.s), () {
+    setStateAsync(animation: Curves.easeInOutExpo.animation(1.s), () {
       _color = _expandedColor;
       _size = (context.findRenderObject()! as RenderBox).size;
     });

--- a/packages/fleet/lib/fleet.dart
+++ b/packages/fleet/lib/fleet.dart
@@ -39,10 +39,6 @@ export 'src/animatable_widget.dart'
         OptionalAnimatableRect,
         OptionalAnimatableSize;
 export 'src/animate.dart'
-    show
-        Animated,
-        FleetBinding,
-        withAnimationAsync,
-        SetStateWithAnimationExtension;
+    show Animated, FleetBinding, withAnimationAsync, AnimatingStateMixin;
 export 'src/animation.dart' show AnimationSpec, AnimationFromCurveExtension;
 export 'src/duration.dart' show DurationFromIntExtension;

--- a/packages/fleet/lib/src/animation.dart
+++ b/packages/fleet/lib/src/animation.dart
@@ -21,7 +21,7 @@ import './animate.dart';
 /// - [speed]
 ///
 /// To apply an [AnimationSpec] to a state change, use [Animated],
-/// [withAnimationAsync] or [SetStateWithAnimationExtension].
+/// [withAnimationAsync] or [AnimatingStateMixin].
 ///
 /// ## Examples
 ///

--- a/packages/fleet/lib/src/transaction.dart
+++ b/packages/fleet/lib/src/transaction.dart
@@ -58,7 +58,7 @@ class Transaction extends StatefulWidget {
   ///
   /// See [Transaction] for more information about transactions.
   static void scheduleTransaction(
-    Object transaction,
+    Object? transaction,
     VoidCallback callback,
   ) {
     TransactionBinding.instance?.scheduleTransaction(transaction, callback);
@@ -131,9 +131,7 @@ class _InheritedTransactionState extends InheritedWidget {
 
   @override
   bool updateShouldNotify(_InheritedTransactionState oldWidget) {
-    // Readers don't care about the ancestor Transaction changing. They only
-    // care about what the transaction value is at the time of the read.
-    return false;
+    return state._transaction != oldWidget.state._transaction;
   }
 }
 
@@ -194,15 +192,17 @@ mixin TransactionBinding on BindingBase, RendererBinding {
   Object? get scheduledTransaction => _scheduledTransaction;
   Object? _scheduledTransaction;
 
-  final List<MapEntry<Object, VoidCallback>> _scheduledTransactions =
-      <MapEntry<Object, VoidCallback>>[];
+  final List<MapEntry<Object?, VoidCallback>> _scheduledTransactions =
+      <MapEntry<Object?, VoidCallback>>[];
 
   final _currentlyExecutingTransactions = <Object?>[];
 
   /// Schedules a transaction to be executed as part of the next frame.
   ///
   /// See [Transaction] for more information about transactions.
-  void scheduleTransaction(Object transaction, VoidCallback callback) {
+  // TODO: Merge consecutive transactions with the same transaction value and
+  //       run them in a single build.
+  void scheduleTransaction(Object? transaction, VoidCallback callback) {
     if (_currentlyExecutingTransactions.isNotEmpty) {
       _executeTransaction(transaction, callback);
     } else {
@@ -234,7 +234,7 @@ mixin TransactionBinding on BindingBase, RendererBinding {
   }
 
   @pragma('vm:notify-debugger-on-exception')
-  void _executeTransaction(Object transaction, VoidCallback callback) {
+  void _executeTransaction(Object? transaction, VoidCallback callback) {
     if (_currentlyExecutingTransactions.isNotEmpty) {
       _flushTransaction();
     }

--- a/packages/fleet/lib/src/transaction.dart
+++ b/packages/fleet/lib/src/transaction.dart
@@ -264,14 +264,14 @@ mixin TransactionBinding on BindingBase, RendererBinding {
   }
 
   void _flushTransaction() {
-    _transactionScope(_currentlyExecutingTransactions.last!, () {
+    _transactionScope(_currentlyExecutingTransactions.last, () {
       buildOwner!.buildScope(renderViewElement!);
       pipelineOwner.flushLayout();
       _clearLocalTransactions();
     });
   }
 
-  void _transactionScope(Object transaction, VoidCallback callback) {
+  void _transactionScope(Object? transaction, VoidCallback callback) {
     final previousTransaction = _scheduledTransaction;
     _scheduledTransaction = transaction;
     try {


### PR DESCRIPTION
Fixes #30